### PR TITLE
Updated workspace manifests to use relative paths to sibling packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,12 @@ members = [
 ]
 default-members = ["ogcapi"]
 
+[workspace.package]
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/georust/ogcapi"
+edition = "2021"
+rust-version = "1.64" # or greater
+
 [patch.crates-io]
 ogcapi-types = { path = "ogcapi-types" }
 ogcapi-drivers = { path = "ogcapi-drivers" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,5 @@ default-members = ["ogcapi"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/georust/ogcapi"
 edition = "2021"
-rust-version = "1.64" # or greater
+rust-version = "1.64"
 
-[patch.crates-io]
-ogcapi-types = { path = "ogcapi-types" }
-ogcapi-drivers = { path = "ogcapi-drivers" }
-ogcapi-services = { path = "ogcapi-services" }
-ogcapi-client = { path = "ogcapi-client" }

--- a/ogcapi-client/Cargo.toml
+++ b/ogcapi-client/Cargo.toml
@@ -2,9 +2,10 @@
 name = "ogcapi-client"
 version = "0.1.0"
 description = "Client to access OGC API Feature and STAC endpoints."
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/camptocamp/ogcapi"
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 [features]
 default = []
@@ -18,6 +19,6 @@ serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.85"
 serde_qs = "0.10.1"
 thiserror = "1.0.35"
-url = { version = "2.3.1", features = ["serde"]}
+url = { version = "2.3.1", features = ["serde"] }
 
-ogcapi-types = "0.1.0"
+ogcapi-types = { path = "../ogcapi-types" }

--- a/ogcapi-drivers/Cargo.toml
+++ b/ogcapi-drivers/Cargo.toml
@@ -2,9 +2,10 @@
 name = "ogcapi-drivers"
 version = "0.1.3"
 description = "Driver traits and implementations"
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/camptocamp/ogcapi"
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 include = ["/src", "/migrations"]
 
@@ -25,4 +26,4 @@ sqlx = { version = "0.6.2", optional = true, features = ["runtime-tokio-rustls",
 tokio = { version = "1.21", features = ["full"] }
 url = { version = "2.3.1", optional = true }
 
-ogcapi-types = "0.1.0"
+ogcapi-types = { path = "../ogcapi-types" }

--- a/ogcapi-services/Cargo.toml
+++ b/ogcapi-services/Cargo.toml
@@ -2,9 +2,11 @@
 name = "ogcapi-services"
 version = "0.1.2"
 description = "Server implementation of several OGC API Standards."
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/camptocamp/ogcapi"
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
 include = ["/src", "/assets"]
 
 [features]
@@ -42,8 +44,8 @@ tracing = "0.1.36"
 tracing-subscriber = { version="0.3.15", features = ["env-filter"] }
 url = { version = "2.3.1", features = ["serde"] }
 
-ogcapi-types = "0.1.0"
-ogcapi-drivers = { version = "0.1.3", features = ["postgres"] }
+ogcapi-types = { path = "../ogcapi-types" }
+ogcapi-drivers = { path = "../ogcapi-drivers", features = ["postgres"] }
 
 
 [dev-dependencies]

--- a/ogcapi-types/Cargo.toml
+++ b/ogcapi-types/Cargo.toml
@@ -2,9 +2,10 @@
 name = "ogcapi-types"
 version = "0.1.0"
 description = "Types as defined by various OGC API Standards."
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/camptocamp/ogcapi"
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 [features]
 default = []

--- a/ogcapi/Cargo.toml
+++ b/ogcapi/Cargo.toml
@@ -2,9 +2,10 @@
 name = "ogcapi"
 version = "0.1.0"
 description = "OGC API building blocks."
-license = "MIT OR Apache-2.0"
-repository = "https://github.com/camptocamp/ogcapi"
-edition = "2021"
+license.workspace = true
+repository.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 [features]
 default = ["types", "client", "drivers", "services", "import"]
@@ -35,7 +36,7 @@ tracing-subscriber = { version = "0.3.15", features = ["env-filter"] }
 url = { version = "2.3.1", optional = true, features = ["serde"] }
 wkb = { version = "0.7.1", optional = true }
 
-ogcapi-types = { version = "0.1.0", optional = true }
-ogcapi-drivers = { version = "0.1.3", optional = true }
-ogcapi-services = { version = "0.1.2", optional = true }
-ogcapi-client = { version = "0.1.0", optional = true }
+ogcapi-types = { path = "../ogcapi-types", optional = true }
+ogcapi-drivers = { path = "../ogcapi-drivers", optional = true }
+ogcapi-services = { path = "../ogcapi-services", optional = true }
+ogcapi-client = { path = "../ogcapi-client", optional = true }


### PR DESCRIPTION
Ensures consistent inter-package cross referencing when imported as a source dependency.

Note: makes use of workspace features released in Rust 1.64.