### PR TITLE
Serialize time extent using to_rfc3339()

### DIFF
--- a/ogcapi-types/src/common/extent.rs
+++ b/ogcapi-types/src/common/extent.rs
@@ -58,7 +58,7 @@ impl Default for TemporalExtent {
     }
 }
 
-pub fn serialize_interval<S>(
+fn serialize_interval<S>(
     interval: &Vec<Vec<Option<DateTime<Utc>>>>,
     serializer: S,
 ) -> Result<S::Ok, S::Error>


### PR DESCRIPTION
This PR changes serialization of the time extent to use the to_rfc3339() function instead of just to_string(), which I believe is in line with the OGC Features Core specification.

Before:
```
"interval": [
  [
    "2024-06-28 06:56:29 UTC",
    null
  ]
],
```
            
After:

```
"interval": [
  [
    "2024-06-28T06:56:29+00:00",
    null
  ]
],
```