### PR TITLE
fix: restore spatial and temporal as optional in Extent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Extent.spatial` and `Extent.temporal` are `Option` again, matching the OGC spec and the published 0.3.0 crate. Regression from #26.
 - Respect process execution `response` parameter.
 - Service URL for OGC API - Features.
 - Minor issues with OGC API - Features conformance.

--- a/examples/data-loader/src/geojson.rs
+++ b/examples/data-loader/src/geojson.rs
@@ -28,14 +28,14 @@ pub async fn load(args: Args) -> anyhow::Result<()> {
         extent: geojson
             .bbox
             .map(|bbox| Extent {
-                spatial: SpatialExtent {
+                spatial: Some(SpatialExtent {
                     bbox: vec![
                         bbox.as_slice()
                             .try_into()
                             .unwrap_or_else(|_| [-180.0, -90.0, 180.0, 90.0].into()),
                     ],
                     crs: Some(Crs::default2d()),
-                },
+                }),
                 ..Default::default()
             })
             .or_else(|| Some(Extent::default())),

--- a/examples/data-loader/src/ogr.rs
+++ b/examples/data-loader/src/ogr.rs
@@ -78,10 +78,10 @@ pub async fn load(mut args: Args) -> Result<(), anyhow::Error> {
             Crs::from_epsg(3857),
         ])),
         extent: layer.try_get_extent()?.map(|e| Extent {
-            spatial: SpatialExtent {
+            spatial: Some(SpatialExtent {
                 bbox: vec![Bbox::Bbox2D([e.MinX, e.MinY, e.MaxX, e.MaxY])],
                 crs: Some(storage_crs.to_owned()),
-            },
+            }),
             ..Default::default()
         }),
         storage_crs: Some(storage_crs.to_owned()),

--- a/ogcapi-types/src/common/extent.rs
+++ b/ogcapi-types/src/common/extent.rs
@@ -9,8 +9,10 @@ use crate::common::{Bbox, Crs};
 /// represent other extents, for example, thermal or pressure ranges.
 #[derive(Serialize, Deserialize, ToSchema, Default, Debug, PartialEq, Clone)]
 pub struct Extent {
-    pub spatial: SpatialExtent,
-    pub temporal: TemporalExtent,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spatial: Option<SpatialExtent>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub temporal: Option<TemporalExtent>,
 }
 
 /// The spatial extent of the features in the collection.


### PR DESCRIPTION
These fields were accidentally made required in #26 (Dynamic openapi generation).                                                                       

The OGC API Features spec does not list them as required, and the published 0.3.0 crate had them as Option. Servers that omit temporal (e.g. collections without time data) cause deserialization failures on the client side.

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "
---
