### PR TITLE
fix: add missing descriptions to process summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Service URL for OGC API - Features.
 - Minor issues with OGC API - Features conformance.
 - Changed enum order when deserializing `processes` inputs, so that the integers would not be deserialized as floats.
+- The description fields were missing in the process summary of the OGC API Processes implementation, so they were added.
 
 ### Changed
 

--- a/ogcapi-processes/src/echo.rs
+++ b/ogcapi-processes/src/echo.rs
@@ -150,6 +150,13 @@ impl Processor for Echo {
             summary: ProcessSummary {
                 id: self.id().to_string(),
                 version: self.version().to_string(),
+                description: DescriptionType {
+                    title: Some("Echo Process".to_string()),
+                    description: Some(
+                        "A simple process that echoes back the inputs it receives.".to_string(),
+                    ),
+                    ..Default::default()
+                },
                 job_control_options: vec![
                     JobControlOptions::SyncExecute,
                     JobControlOptions::AsyncExecute,

--- a/ogcapi-processes/src/greeter.rs
+++ b/ogcapi-processes/src/greeter.rs
@@ -81,6 +81,14 @@ impl Processor for Greeter {
             summary: ProcessSummary {
                 id: self.id().to_string(),
                 version: self.version().to_string(),
+                description: DescriptionType {
+                    title: Some("Greeter".to_string()),
+                    description: Some(
+                        "A simple process that takes a name as input and returns a greeting."
+                            .to_string(),
+                    ),
+                    ..Default::default()
+                },
                 job_control_options: vec![
                     JobControlOptions::SyncExecute,
                     JobControlOptions::AsyncExecute,

--- a/ogcapi-types/src/processes/process.rs
+++ b/ogcapi-types/src/processes/process.rs
@@ -2,7 +2,7 @@ use super::{
     TransmissionMode,
     description::{InputDescription, OutputDescription},
 };
-use crate::common::Link;
+use crate::{common::Link, processes::description::DescriptionType};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use utoipa::ToSchema;
@@ -19,6 +19,8 @@ pub struct ProcessSummary {
     pub output_transmission: Vec<TransmissionMode>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub links: Vec<Link>,
+    #[serde(flatten)]
+    pub description: DescriptionType,
 }
 
 #[derive(Serialize, Deserialize, ToSchema, Debug, Clone, PartialEq, Eq)]


### PR DESCRIPTION
- [X] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [X] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "
---

In OGC API Processes, the process summary should include a [description](https://schemas.opengis.net/ogcapi/processes/part1/1.0/openapi/schemas/descriptionType.yaml), cf. [processSummary.yaml](https://schemas.opengis.net/ogcapi/processes/part1/1.0/openapi/schemas/processSummary.yaml).
But our implementation omitted them, so I added them.