### PR TITLE
fix: serialization and deserialization for TileMatrixSetId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Minor issues with OGC API - Features conformance.
 - Changed enum order when deserializing `processes` inputs, so that the integers would not be deserialized as floats.
 - The description fields were missing in the process summary of the OGC API Processes implementation, so they were added.
+- Fixed serialization of `TileMatrixSetId` in OGC API - Tiles.
 
 ### Changed
 

--- a/ogcapi-types/src/tiles/tms.rs
+++ b/ogcapi-types/src/tiles/tms.rs
@@ -20,6 +20,7 @@ pub enum TileMatrixSetId {
     // WorldCRS84Quad,
     // GNOSISGlobalGrid,
     // WorldMercatorWGS84Quad,
+    #[serde(untagged)]
     Custom(String),
 }
 
@@ -188,7 +189,7 @@ pub enum CornerOfOrigin {
 
 #[cfg(test)]
 mod test {
-    use super::TileMatrixSet;
+    use super::*;
 
     #[test]
     fn parse_tms_example() {
@@ -203,5 +204,24 @@ mod test {
         tms_string.retain(|c| !c.is_whitespace());
 
         assert_eq!(content, tms_string);
+    }
+
+    #[test]
+    fn it_serializes_tms_ids() {
+        let id = TileMatrixSetId::WebMercatorQuad;
+        let serialized = serde_json::to_string(&id).unwrap();
+        assert_eq!(serialized, "\"WebMercatorQuad\"");
+        assert_eq!(
+            serde_json::from_str::<TileMatrixSetId>(&serialized).unwrap(),
+            id
+        );
+
+        let custom_id = TileMatrixSetId::Custom("MyCustomTMS".to_string());
+        let serialized_custom = serde_json::to_string(&custom_id).unwrap();
+        assert_eq!(serialized_custom, "\"MyCustomTMS\"");
+        assert_eq!(
+            serde_json::from_str::<TileMatrixSetId>(&serialized_custom).unwrap(),
+            custom_id
+        );
     }
 }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
  - Usually called `CHANGES.md` or `CHANGELOG.md`
  - Prefix changelog entries for breaking changes with "BREAKING: "
---

From what I've read, the id should always be just a string and not an object:
https://docs.ogc.org/is/20-057/20-057.html#_tilematrixset