### PR TITLE
feat: optional JSON-FG (21-045r1) support behind a json-fg feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow modifying the spawn function (`with_spawn_fn`) in `AppState`, which is used for OGC API - Processes execution, so that it can be adapted, e.g., for applying scopes.
 - Allow modifying the router and OpenAPI definition in the `Service` (`get_router_mut`), e.g., for adding additional paths or for changing the info fields in the OpenAPI definition.
 - Allow modifying the middleware stack in the `Service` (`get_middleware_stack_mut`), e.g., for adding additional middleware or replacing the default ones.
+- Optional JSON-FG (OGC Features and Geometries JSON) support in `ogcapi-types` behind a `json-fg` feature: JSON-FG members on `Feature` and `FeatureCollection` (`place`, `coordRefSys`, `conformsTo`, ...), `into_json_fg` conversions, the `application/vnd.ogc.fg+json` media type, and a re-export of the [`jsonfg`](https://crates.io/crates/jsonfg) crate. By [@georgeboot](https://github.com/georgeboot).
 
 ### Fixed
 
@@ -33,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Changed enum order when deserializing `processes` inputs, so that the integers would not be deserialized as floats.
 - The description fields were missing in the process summary of the OGC API Processes implementation, so they were added.
 - Fixed serialization of `TileMatrixSetId` in OGC API - Tiles.
+- `Collection.keywords` is now gated behind the standards that define it (new `records` feature flag, `stac`, `edr`), so builds without those standards no longer fail to deserialize collections whose `keywords` use a nonconforming extension shape. By [@georgeboot](https://github.com/georgeboot).
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2207,7 +2207,8 @@ dependencies = [
 [[package]]
 name = "jsonfg"
 version = "0.1.0"
-source = "git+https://github.com/360-geo/jsonfg?rev=82126d83268950121837aeae8dafc27e2f3d89d3#82126d83268950121837aeae8dafc27e2f3d89d3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89d6197bc43b86402e9a505b458e9865e6642a2f90a32855ceeb08a1e44e1d9e"
 dependencies = [
  "geojson",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2205,6 +2205,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonfg"
+version = "0.1.0"
+source = "git+https://github.com/360-geo/jsonfg?rev=82126d83268950121837aeae8dafc27e2f3d89d3#82126d83268950121837aeae8dafc27e2f3d89d3"
+dependencies = [
+ "geojson",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2701,6 +2711,7 @@ version = "0.3.0"
 dependencies = [
  "chrono",
  "geojson",
+ "jsonfg",
  "log",
  "serde",
  "serde_json",
@@ -3492,6 +3503,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap 2.13.1",
  "itoa",
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ keywords = ["geography", "geo", "geospatial", "gis", "api"]
 anyhow = "1.0"
 async-trait = "0.1.89"
 geojson = { version = "1.0", default-features = false }
+# Pinned to a revision for now; to be replaced by a crates.io version once `jsonfg` is
+# published. For local development, add a `[patch]` override pointing at a jsonfg checkout.
+jsonfg = { git = "https://github.com/360-geo/jsonfg", rev = "82126d83268950121837aeae8dafc27e2f3d89d3", default-features = false }
 log = "0.4.29"
 serde = "1.0"
 serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,9 +24,7 @@ keywords = ["geography", "geo", "geospatial", "gis", "api"]
 anyhow = "1.0"
 async-trait = "0.1.89"
 geojson = { version = "1.0", default-features = false }
-# Pinned to a revision for now; to be replaced by a crates.io version once `jsonfg` is
-# published. For local development, add a `[patch]` override pointing at a jsonfg checkout.
-jsonfg = { git = "https://github.com/360-geo/jsonfg", rev = "82126d83268950121837aeae8dafc27e2f3d89d3", default-features = false }
+jsonfg = { version = "0.1", default-features = false }
 log = "0.4.29"
 serde = "1.0"
 serde_json = "1.0"

--- a/ogcapi-drivers/src/postgres/edr.rs
+++ b/ogcapi-drivers/src/postgres/edr.rs
@@ -66,8 +66,8 @@ impl EdrQuerier for Db {
                 let mut ctx = rink_core::simple_context().unwrap();
                 let line = format!(
                     "{} {} -> m",
-                    &query.within.to_owned().unwrap_or_else(|| "0".to_string()),
-                    &query
+                    query.within.to_owned().unwrap_or_else(|| "0".to_string()),
+                    query
                         .within_units
                         .to_owned()
                         .unwrap_or_else(|| "m".to_string())

--- a/ogcapi-drivers/src/postgres/feature.rs
+++ b/ogcapi-drivers/src/postgres/feature.rs
@@ -66,7 +66,7 @@ impl FeatureTransactions for Db {
             )
             RETURNING id
             "#,
-            &collection_id
+            collection_id
         ))
         .bind(serde_json::to_value(feature)?)
         .fetch_one(&self.pool)
@@ -111,7 +111,7 @@ impl FeatureTransactions for Db {
                 assets = COALESCE($1 -> 'assets', '{{}}'::jsonb)
             WHERE id = $1 ->> 'id'
             "#,
-            &feature.collection.as_ref().unwrap()
+            feature.collection.as_ref().unwrap()
         ))
         .bind(serde_json::to_value(feature)?)
         .execute(&self.pool)

--- a/ogcapi-services/src/routes/tiles.rs
+++ b/ogcapi-services/src/routes/tiles.rs
@@ -64,7 +64,7 @@ async fn tile_matrix_sets(RemoteUrl(url): RemoteUrl) -> Result<Json<TileMatrixSe
     let tile_matrix_sets = registry
         .iter()
         .map(|tms| {
-            let path = format!("tileMatrixSets/{}", &tms.id);
+            let path = format!("tileMatrixSets/{}", tms.id);
             let url = url.join(&path).expect("failed to parse url");
             let link = Link::new(url, TILING_SCHEME);
             TileMatrixSetItem {

--- a/ogcapi-types/Cargo.toml
+++ b/ogcapi-types/Cargo.toml
@@ -23,10 +23,13 @@ styles = []
 tiles = ["common"]
 coverages = []
 movingfeatures = ["common", "features"]
+# OGC Features and Geometries JSON (JSON-FG) types, re-exported as `ogcapi_types::jsonfg`.
+json-fg = ["features", "dep:jsonfg"]
 
 [dependencies]
 chrono = { version = "0.4.44", features = ["serde"] }
 geojson = { workspace = true }
+jsonfg = { workspace = true, optional = true, features = ["geojson"] }
 log = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
@@ -35,6 +38,9 @@ serde_with = { version = "3.18.0", features = ["json"] }
 serde_qs = { workspace = true }
 url = { workspace = true }
 utoipa = { workspace = true, features = ["preserve_order", "chrono", "url", "repr"] }
+
+[dev-dependencies]
+serde_json = { workspace = true }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/ogcapi-types/src/common/media_type.rs
+++ b/ogcapi-types/src/common/media_type.rs
@@ -12,6 +12,9 @@ pub const HTML: &str = "text/html";
 /// Media Type for `application/json`
 pub const JSON: &str = "application/json";
 
+/// Media Type for `application/vnd.ogc.fg+json` (JSON-FG)
+pub const JSON_FG: &str = "application/vnd.ogc.fg+json";
+
 /// Media Type for `application/vnd.oai.openapi;version=3.0`
 pub const OPEN_API: &str = "application/vnd.oai.openapi;version=3.0";
 

--- a/ogcapi-types/src/features/feature.rs
+++ b/ogcapi-types/src/features/feature.rs
@@ -60,8 +60,57 @@ pub struct Feature {
     pub r#type: Type,
     #[serde(default)]
     pub properties: Option<Map<String, Value>>,
+    /// Declared JSON-FG conformance classes. Set only on the top-level object.
+    #[cfg(feature = "json-fg")]
+    #[serde(
+        rename = "conformsTo",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub conforms_to: Option<Vec<String>>,
+    /// JSON-FG feature classifier(s).
+    #[cfg(feature = "json-fg")]
+    #[serde(
+        rename = "featureType",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    #[schema(value_type = Object)]
+    pub feature_type: Option<jsonfg::FeatureType>,
+    /// Link to the schema of the feature's `properties` (JSON-FG).
+    #[cfg(feature = "json-fg")]
+    #[serde(
+        rename = "featureSchema",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    #[schema(value_type = Object)]
+    pub feature_schema: Option<jsonfg::FeatureSchema>,
+    /// Coordinate reference system of `place` (JSON-FG).
+    #[cfg(feature = "json-fg")]
+    #[serde(
+        rename = "coordRefSys",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    #[schema(value_type = Object)]
+    pub coord_ref_sys: Option<jsonfg::CoordRefSys>,
+    /// The geometry in a non-WGS84 CRS (JSON-FG), which may use solids or curves. When
+    /// set, the GeoJSON `geometry` member is `null`.
+    #[cfg(feature = "json-fg")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Object)]
+    pub place: Option<jsonfg::Geometry>,
+    /// The GeoJSON (WGS 84) geometry.
+    #[cfg(not(feature = "json-fg"))]
     #[schema(schema_with = geometry)]
     pub geometry: Geometry,
+    /// The GeoJSON (WGS 84) geometry, or `null`. Nullable under `json-fg` so it can be
+    /// `null` when the geometry is carried in [`place`](Feature::place).
+    #[cfg(feature = "json-fg")]
+    #[serde(default)]
+    #[schema(schema_with = geometry)]
+    pub geometry: Option<Geometry>,
     /// Bounding Box of the asset represented by this Item, formatted according to RFC 7946, section 5.
     #[cfg(feature = "stac")]
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -118,7 +167,20 @@ impl Feature {
             collection: Default::default(),
             r#type: Default::default(),
             properties: Default::default(),
+            #[cfg(feature = "json-fg")]
+            conforms_to: None,
+            #[cfg(feature = "json-fg")]
+            feature_type: None,
+            #[cfg(feature = "json-fg")]
+            feature_schema: None,
+            #[cfg(feature = "json-fg")]
+            coord_ref_sys: None,
+            #[cfg(feature = "json-fg")]
+            place: None,
+            #[cfg(not(feature = "json-fg"))]
             geometry,
+            #[cfg(feature = "json-fg")]
+            geometry: Some(geometry),
             #[cfg(feature = "stac")]
             bbox: Default::default(),
             links: Default::default(),
@@ -147,5 +209,85 @@ impl Feature {
         } else {
             self.properties = Some(other);
         }
+    }
+}
+
+/// With `json-fg`, `geometry` is nullable, so a `Feature` has a natural empty default
+/// (null geometry, no properties). Lets callers use `..Default::default()`.
+#[cfg(feature = "json-fg")]
+impl Default for Feature {
+    fn default() -> Self {
+        Feature {
+            id: None,
+            collection: None,
+            r#type: Type::Feature,
+            properties: None,
+            conforms_to: None,
+            feature_type: None,
+            feature_schema: None,
+            coord_ref_sys: None,
+            place: None,
+            geometry: None,
+            #[cfg(feature = "stac")]
+            bbox: None,
+            links: Vec::new(),
+            #[cfg(feature = "stac")]
+            stac_version: crate::stac::stac_version(),
+            #[cfg(feature = "stac")]
+            stac_extensions: Vec::new(),
+            #[cfg(feature = "stac")]
+            assets: Default::default(),
+            #[cfg(feature = "movingfeatures")]
+            time: Vec::new(),
+            #[cfg(feature = "movingfeatures")]
+            crs: Default::default(),
+            #[cfg(feature = "movingfeatures")]
+            trs: Default::default(),
+            #[cfg(feature = "movingfeatures")]
+            temporal_geometry: None,
+            #[cfg(feature = "movingfeatures")]
+            temporal_properties: None,
+        }
+    }
+}
+
+/// JSON-FG output conversion.
+#[cfg(feature = "json-fg")]
+impl Feature {
+    /// Rewrite this feature for JSON-FG output given the geometry's `crs`.
+    ///
+    /// Geometry in a non-WGS 84 CRS is moved into [`place`](Feature::place) with a
+    /// [`coord_ref_sys`](Feature::coord_ref_sys), and the GeoJSON `geometry` member is set
+    /// to `null`; WGS 84 (`crs.is_wgs84()`, i.e. CRS84/CRS84h) is kept in `geometry`.
+    /// Top-level `conformsTo` is set. Coordinates are not reprojected.
+    ///
+    /// This is for a single-feature document. For features inside a collection, the
+    /// collection carries `conformsTo`/`coordRefSys` — see
+    /// [`FeatureCollection::into_json_fg`](crate::features::FeatureCollection::into_json_fg).
+    pub fn into_json_fg(self, crs: jsonfg::CoordRefSys) -> Self {
+        self.into_json_fg_scoped(&crs, true)
+    }
+
+    /// As [`into_json_fg`](Feature::into_json_fg); `top_level` gates the feature-level
+    /// `conformsTo`/`coordRefSys` (omitted for features nested in a collection).
+    pub(crate) fn into_json_fg_scoped(
+        mut self,
+        crs: &jsonfg::CoordRefSys,
+        top_level: bool,
+    ) -> Self {
+        let geometry = self.geometry.take();
+        if crs.is_wgs84() {
+            self.geometry = geometry;
+        } else {
+            self.place = geometry.map(jsonfg::Geometry::from);
+            self.geometry = None;
+            if top_level {
+                self.coord_ref_sys = Some(crs.clone());
+            }
+        }
+        if top_level {
+            self.conforms_to = Some(vec![jsonfg::conformance::CORE.to_owned()]);
+        }
+        self
     }
 }

--- a/ogcapi-types/src/features/feature_collection.rs
+++ b/ogcapi-types/src/features/feature_collection.rs
@@ -41,6 +41,24 @@ pub struct FeatureCollection {
     /// of items in the "features" array.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub number_returned: Option<u64>,
+    /// Declared JSON-FG conformance classes (top-level object only).
+    #[cfg(feature = "json-fg")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub conforms_to: Option<Vec<String>>,
+    /// Default coordinate reference system for the features' `place` geometries (JSON-FG).
+    #[cfg(feature = "json-fg")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Object)]
+    pub coord_ref_sys: Option<jsonfg::CoordRefSys>,
+    /// JSON-FG feature classifier(s) shared by the collection.
+    #[cfg(feature = "json-fg")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Object)]
+    pub feature_type: Option<jsonfg::FeatureType>,
+    /// Dimension (0–3) of the geometries in this collection, if uniform (JSON-FG).
+    #[cfg(feature = "json-fg")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub geometry_dimension: Option<u8>,
     #[cfg(feature = "movingfeatures")]
     #[serde(default)]
     pub crs: crate::movingfeatures::crs::Crs,
@@ -61,5 +79,27 @@ impl FeatureCollection {
             number_returned: Some(number_returned as u64),
             ..Default::default()
         }
+    }
+}
+
+/// JSON-FG output conversion.
+#[cfg(feature = "json-fg")]
+impl FeatureCollection {
+    /// Rewrite this collection for JSON-FG output given the geometries' `crs`: set the
+    /// collection-level `conformsTo` and `coordRefSys`, and move each feature's geometry
+    /// into `place` with `geometry` set to `null`. Features inherit the collection CRS, so
+    /// they carry neither their own `coordRefSys` nor `conformsTo`. WGS 84
+    /// (`crs.is_wgs84()`) is kept in `geometry`. Coordinates are not reprojected.
+    pub fn into_json_fg(mut self, crs: jsonfg::CoordRefSys) -> Self {
+        self.conforms_to = Some(vec![jsonfg::conformance::CORE.to_owned()]);
+        if !crs.is_wgs84() {
+            self.coord_ref_sys = Some(crs.clone());
+        }
+        self.features = self
+            .features
+            .into_iter()
+            .map(|f| f.into_json_fg_scoped(&crs, false))
+            .collect();
+        self
     }
 }

--- a/ogcapi-types/src/lib.rs
+++ b/ogcapi-types/src/lib.rs
@@ -25,5 +25,12 @@ pub mod styles;
 #[cfg(feature = "tiles")]
 pub mod tiles;
 
+/// Types for `OGC Features and Geometries JSON` (JSON-FG), re-exported from the
+/// [`jsonfg`] crate. Use these — most importantly [`jsonfg::Geometry`] (which, unlike
+/// [`geojson::Geometry`], can represent solids and curves) and [`jsonfg::Feature`] — to
+/// produce JSON-FG responses. Enabled by the `json-fg` feature.
+#[cfg(feature = "json-fg")]
+pub use jsonfg;
+
 // #[cfg(feature = "coverages")]
 // mod coverages;

--- a/ogcapi-types/tests/json_fg.rs
+++ b/ogcapi-types/tests/json_fg.rs
@@ -1,0 +1,70 @@
+//! JSON-FG support on the OGC API Features types, behind the `json-fg` feature: the extra
+//! members on `Feature`/`FeatureCollection` and the `into_json_fg` conversion helpers.
+#![cfg(feature = "json-fg")]
+
+use ogcapi_types::common::media_type::JSON_FG;
+use ogcapi_types::features::{Feature, FeatureCollection};
+use ogcapi_types::jsonfg::CoordRefSys;
+
+fn geojson_point_feature() -> Feature {
+    serde_json::from_value(serde_json::json!({
+        "type": "Feature",
+        "id": "f1",
+        "geometry": { "type": "Point", "coordinates": [155000.0, 463000.0] },
+        "properties": {}
+    }))
+    .unwrap()
+}
+
+#[test]
+fn media_type_available() {
+    assert_eq!(JSON_FG, "application/vnd.ogc.fg+json");
+}
+
+#[test]
+fn feature_native_crs_goes_to_place() {
+    let v =
+        serde_json::to_value(geojson_point_feature().into_json_fg(CoordRefSys::from_epsg(28992)))
+            .unwrap();
+    assert_eq!(v["place"]["type"], "Point");
+    assert_eq!(
+        v["place"]["coordinates"],
+        serde_json::json!([155000.0, 463000.0])
+    );
+    assert!(v["geometry"].is_null());
+    assert_eq!(
+        v["coordRefSys"],
+        "http://www.opengis.net/def/crs/EPSG/0/28992"
+    );
+    assert!(
+        v["conformsTo"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|u| u.as_str().unwrap().contains("json-fg-1/1.0/conf/core"))
+    );
+}
+
+#[test]
+fn feature_wgs84_stays_in_geometry() {
+    let v =
+        serde_json::to_value(geojson_point_feature().into_json_fg(CoordRefSys::crs84())).unwrap();
+    assert_eq!(v["geometry"]["type"], "Point");
+    assert!(v.get("place").is_none());
+    assert!(v.get("coordRefSys").is_none());
+}
+
+#[test]
+fn collection_sets_crs_once_and_features_omit_it() {
+    let fc = FeatureCollection::new(vec![geojson_point_feature()]);
+    let v = serde_json::to_value(fc.into_json_fg(CoordRefSys::from_epsg(28992))).unwrap();
+    assert_eq!(
+        v["coordRefSys"],
+        "http://www.opengis.net/def/crs/EPSG/0/28992"
+    );
+    // The contained feature inherits the collection CRS and omits its own.
+    assert!(v["features"][0].get("coordRefSys").is_none());
+    assert!(v["features"][0].get("conformsTo").is_none());
+    assert_eq!(v["features"][0]["place"]["type"], "Point");
+    assert!(v["features"][0]["geometry"].is_null());
+}

--- a/ogcapi/Cargo.toml
+++ b/ogcapi/Cargo.toml
@@ -66,6 +66,8 @@ tiles = [
     "ogcapi-drivers?/tiles",
     "ogcapi-services?/tiles",
 ]
+# OGC Features and Geometries JSON (JSON-FG) types (types crate only).
+json-fg = ["types", "ogcapi-types?/json-fg"]
 
 # client
 blocking = ["ogcapi-client?/blocking"]


### PR DESCRIPTION
## What

Adds optional **JSON-FG** (OGC Features and Geometries JSON, 21-045r1) support behind a `json-fg` feature. Off by default — existing consumers are unaffected.

## Changes

- New optional dependency on the **`jsonfg`** crate — a standalone JSON-FG 1.0 data model (a counterpart to `geojson`: the full geometry model incl. solids and curves, `CoordRefSys`, `Time`, `FeatureType`, conformance-class constants).
- `Feature` and `FeatureCollection` gain cfg-gated JSON-FG members (mirroring how `stac`/`movingfeatures` extend them), reusing the `jsonfg` crate's types: `Feature` gets `place`, `coordRefSys`, `conformsTo`, `featureType`, `featureSchema`; `FeatureCollection` gets `conformsTo`, `coordRefSys`, `featureType`, `geometryDimension`.
- Under `json-fg`, `Feature.geometry` becomes `Option<Geometry>` (so it can be `null` when the geometry is carried in `place`). This is gated on the feature, so with `json-fg` off the field type is unchanged — non-breaking.
- `Feature::into_json_fg(crs)` / `FeatureCollection::into_json_fg(crs)` (taking a `jsonfg::CoordRefSys`) convert a GeoJSON feature/collection to JSON-FG: geometry in a non-WGS 84 CRS moves into `place` with `coordRefSys` (`geometry` set to `null`), WGS 84 stays in `geometry`, and top-level `conformsTo` is set. No reprojection.
- Re-export the crate as `ogcapi_types::jsonfg`, plus a `JSON_FG = "application/vnd.ogc.fg+json"` media-type constant and a `json-fg` feature on the umbrella `ogcapi` crate.

Content negotiation is left to the server; this provides the types, the conversion, and the media/conformance constants.
