### PR TITLE
Gate Collection keywords behind the standards that define it

### DIFF
--- a/ogcapi-drivers/src/postgres/edr.rs
+++ b/ogcapi-drivers/src/postgres/edr.rs
@@ -66,8 +66,8 @@ impl EdrQuerier for Db {
                 let mut ctx = rink_core::simple_context().unwrap();
                 let line = format!(
                     "{} {} -> m",
-                    &query.within.to_owned().unwrap_or_else(|| "0".to_string()),
-                    &query
+                    query.within.to_owned().unwrap_or_else(|| "0".to_string()),
+                    query
                         .within_units
                         .to_owned()
                         .unwrap_or_else(|| "m".to_string())

--- a/ogcapi-drivers/src/postgres/feature.rs
+++ b/ogcapi-drivers/src/postgres/feature.rs
@@ -66,7 +66,7 @@ impl FeatureTransactions for Db {
             )
             RETURNING id
             "#,
-            &collection_id
+            collection_id
         ))
         .bind(serde_json::to_value(feature)?)
         .fetch_one(&self.pool)
@@ -111,7 +111,7 @@ impl FeatureTransactions for Db {
                 assets = COALESCE($1 -> 'assets', '{{}}'::jsonb)
             WHERE id = $1 ->> 'id'
             "#,
-            &feature.collection.as_ref().unwrap()
+            feature.collection.as_ref().unwrap()
         ))
         .bind(serde_json::to_value(feature)?)
         .execute(&self.pool)

--- a/ogcapi-services/src/routes/tiles.rs
+++ b/ogcapi-services/src/routes/tiles.rs
@@ -64,7 +64,7 @@ async fn tile_matrix_sets(RemoteUrl(url): RemoteUrl) -> Result<Json<TileMatrixSe
     let tile_matrix_sets = registry
         .iter()
         .map(|tms| {
-            let path = format!("tileMatrixSets/{}", &tms.id);
+            let path = format!("tileMatrixSets/{}", tms.id);
             let url = url.join(&path).expect("failed to parse url");
             let link = Link::new(url, TILING_SCHEME);
             TileMatrixSetItem {

--- a/ogcapi-types/Cargo.toml
+++ b/ogcapi-types/Cargo.toml
@@ -11,13 +11,14 @@ keywords.workspace = true
 include = ["/src", "/assets"]
 
 [features]
-default = ["common", "edr", "features", "movingfeatures", "processes", "tiles"]
+default = ["common", "edr", "features", "movingfeatures", "processes", "records", "tiles"]
 
 # standards
 common = []
 edr = ["common", "features"]
 features = ["common"]
 processes = ["common"]
+records = ["common"]
 stac = ["features"]
 styles = []
 tiles = ["common"]

--- a/ogcapi-types/src/common/collection.rs
+++ b/ogcapi-types/src/common/collection.rs
@@ -185,8 +185,10 @@ mod tests {
     #[cfg(any(feature = "records", feature = "stac", feature = "edr"))]
     #[test]
     fn keywords_roundtrip() {
-        let collection: Collection =
-            serde_json::from_str(r#"{"id": "test", "keywords": ["a", "b"]}"#).unwrap();
+        let collection: Collection = serde_json::from_str(
+            r#"{"id": "test", "keywords": ["a", "b"], "license": "proprietary"}"#,
+        )
+        .unwrap();
         assert_eq!(collection.keywords, vec!["a", "b"]);
         let json = serde_json::to_value(&collection).unwrap();
         assert_eq!(json["keywords"], serde_json::json!(["a", "b"]));

--- a/ogcapi-types/src/common/collection.rs
+++ b/ogcapi-types/src/common/collection.rs
@@ -19,6 +19,14 @@ pub struct Collection {
     pub title: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// Keywords about the elements in the collection.
+    ///
+    /// Defined by OGC API - Records, STAC, and EDR — but not by OGC API - Features
+    /// Part 1, where servers may use the member name for differently-shaped extensions
+    /// (PDOK, for example, returns an array of objects). Gated so builds without these
+    /// standards don't fail deserializing such documents; the raw value then lands in
+    /// `additional_properties` instead.
+    #[cfg(any(feature = "records", feature = "stac", feature = "edr"))]
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub keywords: Vec<String>,
     /// Attribution for the collection.
@@ -118,6 +126,7 @@ impl Default for Collection {
             id: Default::default(),
             title: Default::default(),
             description: Default::default(),
+            #[cfg(any(feature = "records", feature = "stac", feature = "edr"))]
             keywords: Default::default(),
             attribution: Default::default(),
             extent: Default::default(),
@@ -148,5 +157,38 @@ impl Default for Collection {
             update_frequency: Default::default(),
             additional_properties: Default::default(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Collection;
+
+    /// `keywords` is not part of OGC API - Features Part 1, so Features-only builds must
+    /// not fail on servers that use the member name for other shapes — PDOK returns an
+    /// array of objects. The value stays available in `additional_properties`.
+    #[cfg(not(any(feature = "records", feature = "stac", feature = "edr")))]
+    #[test]
+    fn tolerates_non_record_keywords() {
+        let collection: Collection = serde_json::from_str(
+            r#"{
+                "id": "pand",
+                "keywords": [{"keyword": "pand"}, {"keyword": "BAG"}],
+                "extent": {"spatial": {"bbox": [[-1.6, 48.0, 12.4, 56.1]]}}
+            }"#,
+        )
+        .unwrap();
+        assert!(collection.extent.is_some());
+        assert!(collection.additional_properties.contains_key("keywords"));
+    }
+
+    #[cfg(any(feature = "records", feature = "stac", feature = "edr"))]
+    #[test]
+    fn keywords_roundtrip() {
+        let collection: Collection =
+            serde_json::from_str(r#"{"id": "test", "keywords": ["a", "b"]}"#).unwrap();
+        assert_eq!(collection.keywords, vec!["a", "b"]);
+        let json = serde_json::to_value(&collection).unwrap();
+        assert_eq!(json["keywords"], serde_json::json!(["a", "b"]));
     }
 }


### PR DESCRIPTION
## Problem

`Collection.keywords` is typed `Vec<String>` unconditionally, but OGC API - Features Part 1 does not define a `keywords` member on the collection object ([collection.yaml](https://schemas.opengis.net/ogcapi/features/part1/1.0/openapi/schemas/collection.yaml)) — servers are free to use that name for extension content of any shape. PDOK, the Dutch national geo registry, does exactly that and returns an array of objects:

```json
"keywords": [{"keyword": "pand"}, {"keyword": "BAG"}]
```

(live example: https://api.pdok.nl/lv/bgt/ogc/v1/collections/pand?f=json)

Because serde fails the whole document over the one member, a Features-only client built on `ogcapi-types` cannot deserialize *any* collection from such services — even though the response is valid per the spec it implements.

## Change

`keywords` **is** defined as an array of strings by OGC API - Records, STAC, and EDR, so the field is now gated on those: `#[cfg(any(feature = "records", feature = "stac", feature = "edr"))]`, introducing a new `records` feature flag (in the default set, so default builds are unchanged). This follows the existing pattern of the `stac`/`edr`/`movingfeatures` fields on the same struct.

Builds without any of those standards no longer type the member at all — it deserializes into `additional_properties`, where it stays accessible untyped, and nonconforming shapes can no longer fail the document.

## Tests

- `tolerates_non_record_keywords` (features-only): the PDOK-shaped document parses; `keywords` lands in `additional_properties`.
- `keywords_roundtrip` (records/stac/edr): typed behaviour unchanged.

`cargo fmt --check`, `cargo clippy --workspace --all-features --all-targets -- -D warnings`, and `cargo test --workspace --all-features --all-targets` pass locally (except the pre-existing `postgres::job_*` integration tests, which need a database).